### PR TITLE
Custom logger instead of built-in console methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "homepage": "https://github.com/dalisoft/nanoexpress#readme",
   "dependencies": {
     "@dalisoft/events": "^0.0.x",
+    "debug": "^4.1.1",
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v15.11.0"
   },
   "devDependencies": {
@@ -57,10 +58,10 @@
     "rollup-plugin-run": "^1.1.0"
   },
   "peerDependencies": {
+    "ajv": "^6.x",
     "cookie": "^0.x",
     "fast-json-stringify": "^1.x",
     "passport": "^0.4.0",
-    "ajv": "^6.x",
     "swagger-ui-dist": "^3.23.6"
   }
 }

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -3,11 +3,13 @@ import prepareRouteFunctions from './prepare-route-functions';
 import prepareValidation from './prepare-validation';
 import prepareSwaggerDocs from './prepare-swagger-docs';
 import isSimpleHandler from './is-simple-handler';
+import logger from './logger';
 
 export {
   sendFile,
   prepareRouteFunctions,
   prepareValidation,
   prepareSwaggerDocs,
-  isSimpleHandler
+  isSimpleHandler,
+  logger
 };

--- a/src/helpers/logger.js
+++ b/src/helpers/logger.js
@@ -1,0 +1,15 @@
+import createDebug from 'debug';
+
+const log = createDebug('nanoexpress:log');
+log.namespace = `[${log.namespace}]`;
+log.color = 2;
+
+const error = createDebug('nanoexpress:error');
+error.namespace = `[${error.namespace}]`;
+error.color = 1;
+
+log.enabled = error.enabled =
+  !process.env.NODE_ENV ||
+  (process.env.NODE_ENV && process.env.NODE_ENV === 'development');
+
+export default { log, error };

--- a/src/helpers/logger.js
+++ b/src/helpers/logger.js
@@ -8,8 +8,20 @@ const error = createDebug('nanoexpress:error');
 error.namespace = `[${error.namespace}]`;
 error.color = 1;
 
-log.enabled = error.enabled =
-  !process.env.NODE_ENV ||
-  (process.env.NODE_ENV && process.env.NODE_ENV === 'development');
+// Environment checks
+if (!process.env.DEBUG) {
+  // DEBUG passed -> default library flow
+  // DEBUG not passed -> check own directive
+  if (process.env.NANOEXPRESS_LOGGING) {
+    // Extract logging levels
+    const levels = process.env.NANOEXPRESS_LOGGING.split(',');
+    // Enable whitelisted levels
+    log.enabled = levels.includes('log');
+    error.enabled = levels.includes('error');
+  } else {
+    // Development environment -> enable all
+    log.enabled = error.enabled = process.env.NODE_ENV === 'development';
+  }
+}
 
 export default { log, error };

--- a/src/helpers/prepare-validation.js
+++ b/src/helpers/prepare-validation.js
@@ -1,12 +1,13 @@
 import isHttpCode from './is-http-code';
+import logger from '../helpers/logger';
 
 let fastJson;
 
 try {
   fastJson = require('fast-json-stringify');
 } catch (e) {
-  console.error(
-    '[nanoexpress]: `fast-json-stringify` was not found in your dependencies list' +
+  logger.error(
+    '`fast-json-stringify` was not found in your dependencies list' +
       ', please install yourself for this feature working properly'
   );
 }
@@ -50,9 +51,7 @@ export default (ajv, schema, config) => {
       if (typeof _schema === 'object' && _schema) {
         if (type === 'response') {
           if (typeof fastJson !== 'function') {
-            console.error(
-              '[nanoexpress]: `fast-json-stringify` was not initialized properly'
-            );
+            logger.error('`fast-json-stringify` was not initialized properly');
             return;
           }
           const isHttpCodes = Object.keys(_schema).every(isHttpCode);

--- a/src/middlewares/http.js
+++ b/src/middlewares/http.js
@@ -2,7 +2,8 @@ import { http } from '../handler';
 import {
   prepareValidation,
   prepareRouteFunctions,
-  prepareSwaggerDocs
+  prepareSwaggerDocs,
+  logger
 } from '../helpers';
 
 export default (path = '/*', fns, config, ajv, method, app) => {
@@ -49,7 +50,7 @@ export default (path = '/*', fns, config, ajv, method, app) => {
   }
 
   if (route === undefined) {
-    console.error('[nanoexpress]: Route - route function was not defined', {
+    logger.error('Route - route function was not defined', {
       route,
       path,
       method

--- a/src/nanoexpress.js
+++ b/src/nanoexpress.js
@@ -8,6 +8,8 @@ import { getMime, sendFile } from './helpers/sifrr-server';
 
 import { http, ws } from './middlewares';
 
+import logger from './helpers/logger';
+
 const readFile = util.promisify(fs.readFile);
 
 let Ajv;
@@ -15,8 +17,8 @@ let Ajv;
 try {
   Ajv = require('ajv');
 } catch (e) {
-  console.error(
-    '[nanoexpress]: `Ajv` was not found in your dependencies list' +
+  logger.error(
+    '`Ajv` was not found in your dependencies list' +
       ', please install yourself for this feature working properly'
   );
 }
@@ -56,7 +58,7 @@ const nanoexpress = (options = {}) => {
 
   config.setAjv = () => {
     if (typeof Ajv !== 'function') {
-      console.error('[nanoexpress]: `Ajv` was not initialized properly');
+      logger.error('`Ajv` was not initialized properly');
       return;
     }
     ajv = new Ajv(options.ajv);
@@ -94,7 +96,7 @@ const nanoexpress = (options = {}) => {
     listen: (port, host) =>
       new Promise((resolve, reject) => {
         if (port === undefined) {
-          console.log('[Server]: PORT is required');
+          logger.error('[Server]: PORT is required');
           return undefined;
         }
         if (middlewares && middlewares.length > 0 && !middlewares.called) {
@@ -121,14 +123,16 @@ const nanoexpress = (options = {}) => {
 
           if (token) {
             _app._instance = token;
-            console.log(
+            logger.log(
               `[Server]: started successfully at [${
                 config.host
               }:${port}] in [${Date.now() - time}ms]`
             );
             resolve(_app);
           } else {
-            console.log(`[Server]: failed to host at [${config.host}:${port}]`);
+            logger.error(
+              `[Server]: failed to host at [${config.host}:${port}]`
+            );
             reject(
               new Error(`[Server]: failed to host at [${config.host}:${port}]`)
             );
@@ -143,10 +147,10 @@ const nanoexpress = (options = {}) => {
         config.port = null;
         uWS.us_listen_socket_close(_app._instance);
         _app._instance = null;
-        console.log('[Server]: stopped successfully');
+        logger.log('[Server]: stopped successfully');
         return true;
       } else {
-        console.log('[Server]: Error, failed while stopping');
+        logger.error('[Server]: Error, failed while stopping');
         return false;
       }
     },

--- a/src/normalizers/cookies.js
+++ b/src/normalizers/cookies.js
@@ -13,7 +13,7 @@ try {
 
 export default (req, cookies) => {
   if (!cookie || !cookie.parse) {
-    return;
+    return undefined;
   }
   const { headers } = req;
   const headerCookie =

--- a/src/normalizers/cookies.js
+++ b/src/normalizers/cookies.js
@@ -1,10 +1,12 @@
+import logger from '../helpers/logger';
+
 let cookie;
 
 try {
   cookie = require('cookie');
 } catch (e) {
-  console.error(
-    '[nanoexpress]: `cookie` was not found in your dependencies list' +
+  logger.error(
+    '`cookie` was not found in your dependencies list' +
       ', please install yourself for this feature working properly'
   );
 }

--- a/src/proto/http/cookie-chunks/set-cookie.js
+++ b/src/proto/http/cookie-chunks/set-cookie.js
@@ -13,7 +13,7 @@ try {
 
 export default function setCookie(name, value, options) {
   if (!cookie || !cookie.serialize) {
-    return;
+    return undefined;
   }
 
   if (options.expires && Number.isInteger(options.expires)) {

--- a/src/proto/http/cookie-chunks/set-cookie.js
+++ b/src/proto/http/cookie-chunks/set-cookie.js
@@ -1,10 +1,12 @@
+import logger from '../../../helpers/logger';
+
 let cookie;
 
 try {
   cookie = require('cookie');
 } catch (e) {
-  console.error(
-    '[nanoexpress]: `cookie` was not found in your dependencies list' +
+  logger.error(
+    '`cookie` was not found in your dependencies list' +
       ', please install yourself for this feature working properly'
   );
 }

--- a/src/proto/http/response-chunks/send.js
+++ b/src/proto/http/response-chunks/send.js
@@ -1,7 +1,9 @@
+import logger from '../../../helpers/logger';
+
 export default function send(result) {
   /* If we were aborted, you cannot respond */
   if (this.aborted) {
-    console.error('[Server]: Error, Response was aborted before responsing');
+    logger.error('[Server]: Error, Response was aborted before responsing');
     return undefined;
   }
   if (this._headers && this.writeHead && !this._headWritten && !this.aborted) {


### PR DESCRIPTION
### Changelog

- Replaced `console` methods with custom logger
   Namespaces
   - `nanoexpress:log` instead of `console.log`
   - `nanoexpress:error` instead of `console.log` for errors
- Replaced all `console` methods occurencies with `logger` methods
   - For errors : `logger.error`
   - For info messages : `logger.log`

---

### Environment checks

- `process.env.DEBUG` for `debug` library usual flow
- `process.env.NANOEXPRESS_LOGGING` if `DEBUG` is missing
- `process.env.NODE_ENV` if both `DEBUG` and `NANOEXPRESS_LOGGING` are missing