### PR TITLE
Add `getIP` to Typescript typings

### DIFF
--- a/nanoexpress.d.ts
+++ b/nanoexpress.d.ts
@@ -51,6 +51,7 @@ declare namespace nanoexpress {
     cookies: HttpRequestCookies;
     query: HttpRequestQueries;
     params: HttpRequestParams;
+    getIP(): string;
     body?: HttpRequestBody;
     __response?: HttpResponse;
   }


### PR DESCRIPTION
It appears that we have `getIP` method which doesn't exist in TS typings.
https://github.com/dalisoft/nanoexpress/blob/master/src/wrappers/http/request.js#L21